### PR TITLE
Adds *args input to __init__ method to fix test testFruitNullValue

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model.mustache
@@ -10,6 +10,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from {{packageName}}.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/method_init_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/method_init_shared.mustache
@@ -1,5 +1,5 @@
     @convert_js_args_to_python_args
-    def __init__(self{{#requiredVars}}{{^defaultValue}}, {{name}}{{/defaultValue}}{{/requiredVars}}{{#requiredVars}}{{#defaultValue}}, {{name}}={{{defaultValue}}}{{/defaultValue}}{{/requiredVars}}, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self{{#requiredVars}}{{^defaultValue}}, {{name}}{{/defaultValue}}{{/requiredVars}}, *args, **kwargs):  # noqa: E501
         """{{classname}} - a model defined in OpenAPI
 
 {{#requiredVars}}
@@ -53,6 +53,27 @@
             {{name}} ({{{dataType}}}):{{#description}} {{description}}.{{/description}} [optional]{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}  # noqa: E501
 {{/optionalVars}}
         """
+
+{{#requiredVars}}
+{{#defaultValue}}
+        {{name}} = kwargs.get('{{name}}', {{{defaultValue}}})
+{{/defaultValue}}
+{{/requiredVars}}
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/additional_properties_class.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -116,7 +117,7 @@ class AdditionalPropertiesClass(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """additional_properties_class.AdditionalPropertiesClass - a model defined in OpenAPI
 
         Keyword Args:
@@ -159,6 +160,22 @@ class AdditionalPropertiesClass(ModelNormal):
             empty_map (bool, date, datetime, dict, float, int, list, str): an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.. [optional]  # noqa: E501
             map_with_undeclared_properties_string ({str: (str,)}): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/address.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/address.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -100,7 +101,7 @@ class Address(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """address.Address - a model defined in OpenAPI
 
         Keyword Args:
@@ -135,6 +136,22 @@ class Address(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/animal.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -120,7 +121,7 @@ class Animal(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """animal.Animal - a model defined in OpenAPI
 
         Args:
@@ -159,6 +160,22 @@ class Animal(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             color (str): [optional] if omitted the server will use the default value of 'red'  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/api_response.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -106,7 +107,7 @@ class ApiResponse(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """api_response.ApiResponse - a model defined in OpenAPI
 
         Keyword Args:
@@ -144,6 +145,22 @@ class ApiResponse(ModelNormal):
             type (str): [optional]  # noqa: E501
             message (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/apple.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/apple.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -115,7 +116,7 @@ class Apple(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """apple.Apple - a model defined in OpenAPI
 
         Keyword Args:
@@ -152,6 +153,22 @@ class Apple(ModelNormal):
             cultivar (str): [optional]  # noqa: E501
             origin (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/apple_req.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/apple_req.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class AppleReq(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, cultivar, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, cultivar, *args, **kwargs):  # noqa: E501
         """apple_req.AppleReq - a model defined in OpenAPI
 
         Args:
@@ -143,6 +144,22 @@ class AppleReq(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             mealy (bool): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/array_of_array_of_number_only.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """array_of_array_of_number_only.ArrayOfArrayOfNumberOnly - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             array_array_number ([[float]]): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/array_of_number_only.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class ArrayOfNumberOnly(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """array_of_number_only.ArrayOfNumberOnly - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class ArrayOfNumberOnly(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             array_number ([float]): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/array_test.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -111,7 +112,7 @@ class ArrayTest(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """array_test.ArrayTest - a model defined in OpenAPI
 
         Keyword Args:
@@ -149,6 +150,22 @@ class ArrayTest(ModelNormal):
             array_array_of_integer ([[int]]): [optional]  # noqa: E501
             array_array_of_model ([[read_only_first.ReadOnlyFirst]]): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/banana.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/banana.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class Banana(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """banana.Banana - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class Banana(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             length_cm (float): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/banana_req.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/banana_req.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class BananaReq(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, length_cm, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, length_cm, *args, **kwargs):  # noqa: E501
         """banana_req.BananaReq - a model defined in OpenAPI
 
         Args:
@@ -143,6 +144,22 @@ class BananaReq(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             sweet (bool): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_chordate.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_chordate.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -130,7 +131,7 @@ class BiologyChordate(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """biology_chordate.BiologyChordate - a model defined in OpenAPI
 
         Args:
@@ -168,6 +169,22 @@ class BiologyChordate(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_hominid.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_hominid.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -112,7 +113,7 @@ class BiologyHominid(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """biology_hominid.BiologyHominid - a model defined in OpenAPI
 
         Args:
@@ -150,6 +151,22 @@ class BiologyHominid(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_mammal.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_mammal.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -124,7 +125,7 @@ class BiologyMammal(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """biology_mammal.BiologyMammal - a model defined in OpenAPI
 
         Args:
@@ -162,6 +163,22 @@ class BiologyMammal(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_primate.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_primate.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -118,7 +119,7 @@ class BiologyPrimate(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """biology_primate.BiologyPrimate - a model defined in OpenAPI
 
         Args:
@@ -156,6 +157,22 @@ class BiologyPrimate(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_reptile.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/biology_reptile.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -112,7 +113,7 @@ class BiologyReptile(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """biology_reptile.BiologyReptile - a model defined in OpenAPI
 
         Args:
@@ -150,6 +151,22 @@ class BiologyReptile(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/capitalization.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -112,7 +113,7 @@ class Capitalization(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """capitalization.Capitalization - a model defined in OpenAPI
 
         Keyword Args:
@@ -153,6 +154,22 @@ class Capitalization(ModelNormal):
             sca_eth_flow_points (str): [optional]  # noqa: E501
             att_name (str): Name of the pet . [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/cat.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -126,7 +127,7 @@ class Cat(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """cat.Cat - a model defined in OpenAPI
 
         Args:
@@ -166,6 +167,22 @@ class Cat(ModelComposed):
             declawed (bool): [optional]  # noqa: E501
             color (str): [optional] if omitted the server will use the default value of 'red'  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/cat_all_of.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/cat_all_of.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class CatAllOf(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """cat_all_of.CatAllOf - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class CatAllOf(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             declawed (bool): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/category.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class Category(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, name='default-name', _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """category.Category - a model defined in OpenAPI
 
         Args:
@@ -143,6 +144,23 @@ class Category(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             id (int): [optional]  # noqa: E501
         """
+
+        name = kwargs.get('name', 'default-name')
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/class_model.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class ClassModel(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """class_model.ClassModel - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class ClassModel(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             _class (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/client.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class Client(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """client.Client - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class Client(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             client (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/complex_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/complex_quadrilateral.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -115,7 +116,7 @@ class ComplexQuadrilateral(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, quadrilateral_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, quadrilateral_type, *args, **kwargs):  # noqa: E501
         """complex_quadrilateral.ComplexQuadrilateral - a model defined in OpenAPI
 
         Args:
@@ -154,6 +155,22 @@ class ComplexQuadrilateral(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/dog.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -121,7 +122,7 @@ class Dog(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """dog.Dog - a model defined in OpenAPI
 
         Args:
@@ -161,6 +162,22 @@ class Dog(ModelComposed):
             breed (str): [optional]  # noqa: E501
             color (str): [optional] if omitted the server will use the default value of 'red'  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/dog_all_of.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/dog_all_of.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class DogAllOf(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """dog_all_of.DogAllOf - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class DogAllOf(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             breed (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/drawing.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/drawing.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -128,7 +129,7 @@ class Drawing(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """drawing.Drawing - a model defined in OpenAPI
 
         Keyword Args:
@@ -167,6 +168,22 @@ class Drawing(ModelNormal):
             nullable_shape (nullable_shape.NullableShape): [optional]  # noqa: E501
             shapes ([shape.Shape]): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/enum_arrays.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -112,7 +113,7 @@ class EnumArrays(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """enum_arrays.EnumArrays - a model defined in OpenAPI
 
         Keyword Args:
@@ -149,6 +150,22 @@ class EnumArrays(ModelNormal):
             just_symbol (str): [optional]  # noqa: E501
             array_enum ([str]): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/enum_class.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -99,7 +100,7 @@ class EnumClass(ModelSimple):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, value='-efg', _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """enum_class.EnumClass - a model defined in OpenAPI
 
         Args:
@@ -137,6 +138,23 @@ class EnumClass(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        value = kwargs.get('value', '-efg')
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/enum_test.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -154,7 +155,7 @@ class EnumTest(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, enum_string_required, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, enum_string_required, *args, **kwargs):  # noqa: E501
         """enum_test.EnumTest - a model defined in OpenAPI
 
         Args:
@@ -199,6 +200,22 @@ class EnumTest(ModelNormal):
             outer_enum_default_value (outer_enum_default_value.OuterEnumDefaultValue): [optional]  # noqa: E501
             outer_enum_integer_default_value (outer_enum_integer_default_value.OuterEnumIntegerDefaultValue): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/equilateral_triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/equilateral_triangle.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -115,7 +116,7 @@ class EquilateralTriangle(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, triangle_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, triangle_type, *args, **kwargs):  # noqa: E501
         """equilateral_triangle.EquilateralTriangle - a model defined in OpenAPI
 
         Args:
@@ -154,6 +155,22 @@ class EquilateralTriangle(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/file.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class File(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """file.File - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class File(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             source_uri (str): Test capitalization. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/file_schema_test_class.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -109,7 +110,7 @@ class FileSchemaTestClass(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """file_schema_test_class.FileSchemaTestClass - a model defined in OpenAPI
 
         Keyword Args:
@@ -146,6 +147,22 @@ class FileSchemaTestClass(ModelNormal):
             file (file.File): [optional]  # noqa: E501
             files ([file.File]): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/foo.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class Foo(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """foo.Foo - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class Foo(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             bar (str): [optional] if omitted the server will use the default value of 'bar'  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/format_test.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -173,7 +174,7 @@ class FormatTest(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, number, byte, date, password, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, number, byte, date, password, *args, **kwargs):  # noqa: E501
         """format_test.FormatTest - a model defined in OpenAPI
 
         Args:
@@ -225,6 +226,22 @@ class FormatTest(ModelNormal):
             pattern_with_digits (str): A string that is a 10 digit number. Can have leading zeros.. [optional]  # noqa: E501
             pattern_with_digits_and_delimiter (str): A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/fruit.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -130,7 +131,7 @@ class Fruit(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """fruit.Fruit - a model defined in OpenAPI
 
         Keyword Args:
@@ -169,6 +170,22 @@ class Fruit(ModelComposed):
             origin (str): [optional]  # noqa: E501
             length_cm (float): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/fruit_req.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/fruit_req.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -119,7 +120,7 @@ class FruitReq(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, cultivar=nulltype.Null, length_cm=nulltype.Null, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """fruit_req.FruitReq - a model defined in OpenAPI
 
         Args:
@@ -160,6 +161,24 @@ class FruitReq(ModelComposed):
             mealy (bool): [optional]  # noqa: E501
             sweet (bool): [optional]  # noqa: E501
         """
+
+        cultivar = kwargs.get('cultivar', nulltype.Null)
+        length_cm = kwargs.get('length_cm', nulltype.Null)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/gm_fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/gm_fruit.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -130,7 +131,7 @@ class GmFruit(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """gm_fruit.GmFruit - a model defined in OpenAPI
 
         Keyword Args:
@@ -169,6 +170,22 @@ class GmFruit(ModelComposed):
             origin (str): [optional]  # noqa: E501
             length_cm (float): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/has_only_read_only.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class HasOnlyReadOnly(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """has_only_read_only.HasOnlyReadOnly - a model defined in OpenAPI
 
         Keyword Args:
@@ -141,6 +142,22 @@ class HasOnlyReadOnly(ModelNormal):
             bar (str): [optional]  # noqa: E501
             foo (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/health_check_result.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class HealthCheckResult(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """health_check_result.HealthCheckResult - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class HealthCheckResult(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             nullable_message (str, none_type): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class InlineObject(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """inline_object.InlineObject - a model defined in OpenAPI
 
         Keyword Args:
@@ -141,6 +142,22 @@ class InlineObject(ModelNormal):
             name (str): Updated name of the pet. [optional]  # noqa: E501
             status (str): Updated status of the pet. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object1.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object1.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class InlineObject1(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """inline_object1.InlineObject1 - a model defined in OpenAPI
 
         Keyword Args:
@@ -141,6 +142,22 @@ class InlineObject1(ModelNormal):
             additional_metadata (str): Additional data to pass to server. [optional]  # noqa: E501
             file (file_type): file to upload. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object2.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object2.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -113,7 +114,7 @@ class InlineObject2(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """inline_object2.InlineObject2 - a model defined in OpenAPI
 
         Keyword Args:
@@ -150,6 +151,22 @@ class InlineObject2(ModelNormal):
             enum_form_string_array ([str]): Form parameter enum test (string array). [optional]  # noqa: E501
             enum_form_string (str): Form parameter enum test (string). [optional] if omitted the server will use the default value of '-efg'  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object3.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object3.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -162,7 +163,7 @@ class InlineObject3(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, number, double, pattern_without_delimiter, byte, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, number, double, pattern_without_delimiter, byte, *args, **kwargs):  # noqa: E501
         """inline_object3.InlineObject3 - a model defined in OpenAPI
 
         Args:
@@ -213,6 +214,22 @@ class InlineObject3(ModelNormal):
             password (str): None. [optional]  # noqa: E501
             callback (str): None. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object4.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object4.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class InlineObject4(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, param, param2, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, param, param2, *args, **kwargs):  # noqa: E501
         """inline_object4.InlineObject4 - a model defined in OpenAPI
 
         Args:
@@ -143,6 +144,22 @@ class InlineObject4(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object5.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_object5.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class InlineObject5(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, required_file, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, required_file, *args, **kwargs):  # noqa: E501
         """inline_object5.InlineObject5 - a model defined in OpenAPI
 
         Args:
@@ -143,6 +144,22 @@ class InlineObject5(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             additional_metadata (str): Additional data to pass to server. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_response_default.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/inline_response_default.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -107,7 +108,7 @@ class InlineResponseDefault(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """inline_response_default.InlineResponseDefault - a model defined in OpenAPI
 
         Keyword Args:
@@ -143,6 +144,22 @@ class InlineResponseDefault(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             string (foo.Foo): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/isosceles_triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/isosceles_triangle.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -115,7 +116,7 @@ class IsoscelesTriangle(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, triangle_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, triangle_type, *args, **kwargs):  # noqa: E501
         """isosceles_triangle.IsoscelesTriangle - a model defined in OpenAPI
 
         Args:
@@ -154,6 +155,22 @@ class IsoscelesTriangle(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/list.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class List(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """list.List - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class List(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             _123_list (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/mammal.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/mammal.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -130,7 +131,7 @@ class Mammal(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """mammal.Mammal - a model defined in OpenAPI
 
         Args:
@@ -171,6 +172,22 @@ class Mammal(ModelComposed):
             has_teeth (bool): [optional]  # noqa: E501
             type (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/map_test.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -117,7 +118,7 @@ class MapTest(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """map_test.MapTest - a model defined in OpenAPI
 
         Keyword Args:
@@ -156,6 +157,22 @@ class MapTest(ModelNormal):
             direct_map ({str: (bool,)}): [optional]  # noqa: E501
             indirect_map (string_boolean_map.StringBooleanMap): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -111,7 +112,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """mixed_properties_and_additional_properties_class.MixedPropertiesAndAdditionalPropertiesClass - a model defined in OpenAPI
 
         Keyword Args:
@@ -149,6 +150,22 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
             date_time (datetime): [optional]  # noqa: E501
             map ({str: (animal.Animal,)}): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/model200_response.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class Model200Response(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """model200_response.Model200Response - a model defined in OpenAPI
 
         Keyword Args:
@@ -141,6 +142,22 @@ class Model200Response(ModelNormal):
             name (int): [optional]  # noqa: E501
             _class (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/model_return.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class ModelReturn(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """model_return.ModelReturn - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class ModelReturn(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             _return (int): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/name.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -108,7 +109,7 @@ class Name(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, name, *args, **kwargs):  # noqa: E501
         """name.Name - a model defined in OpenAPI
 
         Args:
@@ -149,6 +150,22 @@ class Name(ModelNormal):
             _property (str): [optional]  # noqa: E501
             _123_number (int): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/nullable_class.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -124,7 +125,7 @@ class NullableClass(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """nullable_class.NullableClass - a model defined in OpenAPI
 
         Keyword Args:
@@ -171,6 +172,22 @@ class NullableClass(ModelNormal):
             object_and_items_nullable_prop ({str: ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}, none_type)}, none_type): [optional]  # noqa: E501
             object_items_nullable ({str: ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}, none_type)}): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/nullable_shape.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/nullable_shape.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -123,7 +124,7 @@ class NullableShape(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, quadrilateral_type=nulltype.Null, triangle_type=nulltype.Null, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, *args, **kwargs):  # noqa: E501
         """nullable_shape.NullableShape - a model defined in OpenAPI
 
         Args:
@@ -163,6 +164,24 @@ class NullableShape(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        quadrilateral_type = kwargs.get('quadrilateral_type', nulltype.Null)
+        triangle_type = kwargs.get('triangle_type', nulltype.Null)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/number_only.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class NumberOnly(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """number_only.NumberOnly - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class NumberOnly(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             just_number (float): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/order.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -117,7 +118,7 @@ class Order(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """order.Order - a model defined in OpenAPI
 
         Keyword Args:
@@ -158,6 +159,22 @@ class Order(ModelNormal):
             status (str): Order Status. [optional]  # noqa: E501
             complete (bool): [optional] if omitted the server will use the default value of False  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_composite.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -106,7 +107,7 @@ class OuterComposite(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """outer_composite.OuterComposite - a model defined in OpenAPI
 
         Keyword Args:
@@ -144,6 +145,22 @@ class OuterComposite(ModelNormal):
             my_string (str): [optional]  # noqa: E501
             my_boolean (bool): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -100,7 +101,7 @@ class OuterEnum(ModelSimple):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, value, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, value, *args, **kwargs):  # noqa: E501
         """outer_enum.OuterEnum - a model defined in OpenAPI
 
         Args:
@@ -138,6 +139,22 @@ class OuterEnum(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum_default_value.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -99,7 +100,7 @@ class OuterEnumDefaultValue(ModelSimple):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, value='placed', _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """outer_enum_default_value.OuterEnumDefaultValue - a model defined in OpenAPI
 
         Args:
@@ -137,6 +138,23 @@ class OuterEnumDefaultValue(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        value = kwargs.get('value', 'placed')
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum_integer.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -99,7 +100,7 @@ class OuterEnumInteger(ModelSimple):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, value, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, value, *args, **kwargs):  # noqa: E501
         """outer_enum_integer.OuterEnumInteger - a model defined in OpenAPI
 
         Args:
@@ -137,6 +138,22 @@ class OuterEnumInteger(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/outer_enum_integer_default_value.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -99,7 +100,7 @@ class OuterEnumIntegerDefaultValue(ModelSimple):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, value=0, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """outer_enum_integer_default_value.OuterEnumIntegerDefaultValue - a model defined in OpenAPI
 
         Args:
@@ -137,6 +138,23 @@ class OuterEnumIntegerDefaultValue(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        value = kwargs.get('value', 0)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/pet.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -127,7 +128,7 @@ class Pet(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, name, photo_urls, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, name, photo_urls, *args, **kwargs):  # noqa: E501
         """pet.Pet - a model defined in OpenAPI
 
         Args:
@@ -170,6 +171,22 @@ class Pet(ModelNormal):
             tags ([tag.Tag]): [optional]  # noqa: E501
             status (str): pet status in the store. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/quadrilateral.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/quadrilateral.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -121,7 +122,7 @@ class Quadrilateral(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, quadrilateral_type, shape_type=nulltype.Null, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, quadrilateral_type, *args, **kwargs):  # noqa: E501
         """quadrilateral.Quadrilateral - a model defined in OpenAPI
 
         Args:
@@ -160,6 +161,23 @@ class Quadrilateral(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        shape_type = kwargs.get('shape_type', nulltype.Null)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/quadrilateral_interface.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/quadrilateral_interface.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class QuadrilateralInterface(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, quadrilateral_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, quadrilateral_type, *args, **kwargs):  # noqa: E501
         """quadrilateral_interface.QuadrilateralInterface - a model defined in OpenAPI
 
         Args:
@@ -140,6 +141,22 @@ class QuadrilateralInterface(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/read_only_first.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class ReadOnlyFirst(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """read_only_first.ReadOnlyFirst - a model defined in OpenAPI
 
         Keyword Args:
@@ -141,6 +142,22 @@ class ReadOnlyFirst(ModelNormal):
             bar (str): [optional]  # noqa: E501
             baz (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/scalene_triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/scalene_triangle.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -115,7 +116,7 @@ class ScaleneTriangle(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, triangle_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, triangle_type, *args, **kwargs):  # noqa: E501
         """scalene_triangle.ScaleneTriangle - a model defined in OpenAPI
 
         Args:
@@ -154,6 +155,22 @@ class ScaleneTriangle(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/shape.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/shape.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -123,7 +124,7 @@ class Shape(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, quadrilateral_type=nulltype.Null, triangle_type=nulltype.Null, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, *args, **kwargs):  # noqa: E501
         """shape.Shape - a model defined in OpenAPI
 
         Args:
@@ -163,6 +164,24 @@ class Shape(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        quadrilateral_type = kwargs.get('quadrilateral_type', nulltype.Null)
+        triangle_type = kwargs.get('triangle_type', nulltype.Null)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/shape_interface.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/shape_interface.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class ShapeInterface(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, *args, **kwargs):  # noqa: E501
         """shape_interface.ShapeInterface - a model defined in OpenAPI
 
         Args:
@@ -140,6 +141,22 @@ class ShapeInterface(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/shape_or_null.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/shape_or_null.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -123,7 +124,7 @@ class ShapeOrNull(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, quadrilateral_type=nulltype.Null, triangle_type=nulltype.Null, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, *args, **kwargs):  # noqa: E501
         """shape_or_null.ShapeOrNull - a model defined in OpenAPI
 
         Args:
@@ -163,6 +164,24 @@ class ShapeOrNull(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        quadrilateral_type = kwargs.get('quadrilateral_type', nulltype.Null)
+        triangle_type = kwargs.get('triangle_type', nulltype.Null)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/simple_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/simple_quadrilateral.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -115,7 +116,7 @@ class SimpleQuadrilateral(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, shape_type, quadrilateral_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, shape_type, quadrilateral_type, *args, **kwargs):  # noqa: E501
         """simple_quadrilateral.SimpleQuadrilateral - a model defined in OpenAPI
 
         Args:
@@ -154,6 +155,22 @@ class SimpleQuadrilateral(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/special_model_name.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class SpecialModelName(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """special_model_name.SpecialModelName - a model defined in OpenAPI
 
         Keyword Args:
@@ -138,6 +139,22 @@ class SpecialModelName(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             special_property_name (int): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/string_boolean_map.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/string_boolean_map.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -100,7 +101,7 @@ class StringBooleanMap(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """string_boolean_map.StringBooleanMap - a model defined in OpenAPI
 
         Keyword Args:
@@ -135,6 +136,22 @@ class StringBooleanMap(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/tag.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -104,7 +105,7 @@ class Tag(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """tag.Tag - a model defined in OpenAPI
 
         Keyword Args:
@@ -141,6 +142,22 @@ class Tag(ModelNormal):
             id (int): [optional]  # noqa: E501
             name (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/triangle.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -127,7 +128,7 @@ class Triangle(ModelComposed):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, triangle_type, shape_type=nulltype.Null, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, triangle_type, *args, **kwargs):  # noqa: E501
         """triangle.Triangle - a model defined in OpenAPI
 
         Args:
@@ -166,6 +167,23 @@ class Triangle(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        shape_type = kwargs.get('shape_type', nulltype.Null)
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/triangle_interface.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/triangle_interface.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -102,7 +103,7 @@ class TriangleInterface(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, triangle_type, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, triangle_type, *args, **kwargs):  # noqa: E501
         """triangle_interface.TriangleInterface - a model defined in OpenAPI
 
         Args:
@@ -140,6 +141,22 @@ class TriangleInterface(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/user.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -124,7 +125,7 @@ class User(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """user.User - a model defined in OpenAPI
 
         Keyword Args:
@@ -171,6 +172,22 @@ class User(ModelNormal):
             any_type_prop (bool, date, datetime, dict, float, int, list, str, none_type): test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389. [optional]  # noqa: E501
             any_type_prop_nullable (bool, date, datetime, dict, float, int, list, str, none_type): test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.. [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/whale.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/whale.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -106,7 +107,7 @@ class Whale(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """whale.Whale - a model defined in OpenAPI
 
         Args:
@@ -146,6 +147,22 @@ class Whale(ModelNormal):
             has_baleen (bool): [optional]  # noqa: E501
             has_teeth (bool): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/models/zebra.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/models/zebra.py
@@ -18,6 +18,7 @@ import six  # noqa: F401
 import nulltype  # noqa: F401
 
 from petstore_api.model_utils import (  # noqa: F401
+    ApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -109,7 +110,7 @@ class Zebra(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, class_name, _check_type=True, _spec_property_naming=False, _path_to_item=(), _configuration=None, _visited_composed_classes=(), **kwargs):  # noqa: E501
+    def __init__(self, class_name, *args, **kwargs):  # noqa: E501
         """zebra.Zebra - a model defined in OpenAPI
 
         Args:
@@ -148,6 +149,22 @@ class Zebra(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             type (str): [optional]  # noqa: E501
         """
+
+        _check_type = kwargs.pop('_check_type', True)
+        _spec_property_naming = kwargs.pop('_spec_property_naming', False)
+        _path_to_item = kwargs.pop('_path_to_item', ())
+        _configuration = kwargs.pop('_configuration', None)
+        _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
+
+        if args:
+            raise ApiTypeError(
+                "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
+                    args,
+                    self.__class__.__name__,
+                ),
+                path_to_item=_path_to_item,
+                valid_classes=(self.__class__,),
+            )
 
         self._data_store = {}
         self._check_type = _check_type

--- a/samples/openapi3/client/petstore/python-experimental/test/test_fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/test/test_fruit.py
@@ -194,10 +194,9 @@ class TestFruit(unittest.TestCase):
         apple = petstore_api.Apple(None)
         self.assertIsNone(apple)
 
-        # But 'banana' is not nullable.
-        banana = petstore_api.Banana(None)
-        # TODO: this does not seem right. Shouldn't this raise an exception?
-        assert isinstance(banana, petstore_api.Banana)
+        # 'banana' is not nullable.
+        with self.assertRaises(petstore_api.ApiTypeError):
+            banana = petstore_api.Banana(None)
 
         # Since 'fruit' has oneOf 'apple', 'banana' and 'apple' is nullable,
         # validate we can create a fruit with the 'null' value.


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
