### PR TITLE
Fix for python dictionary conversion issue and improper data type

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/methods_setattr_getattr_composed.mustache
@@ -34,9 +34,12 @@
                     [e for e in [self._path_to_item, name] if e]
                 )
         # attribute must be set on self and composed instances
-        self.set_attribute(name, value)
-        for model_instance in self._composed_instances:
-            setattr(model_instance, name, value)
+        model_instances = self._var_name_to_model_instances.get(name, self._additional_properties_model_instances)
+        for model_instance in model_instances:
+            if model_instance == self:
+                self.set_attribute(name, value)
+            else:
+                setattr(model_instance, name, value)
         if name not in self._var_name_to_model_instances:
             # we assigned an additional property
             self.__dict__['_var_name_to_model_instances'][name] = self._composed_instances + [self]

--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1478,10 +1478,14 @@ def get_allof_instances(self, model_args, constant_args):
     """
     composed_instances = []
     for allof_class in self._composed_schemas['allOf']:
-
+        allof_model_args = {}
+        var_names = set(allof_class.openapi_types.keys())
+        for var_name in var_names:
+            if var_name in model_args:
+                allof_model_args[var_name] = model_args[var_name]
         try:
             if constant_args.get('_spec_property_naming'):
-                allof_instance = allof_class._from_openapi_data(**model_args, **constant_args)
+                allof_instance = allof_class._from_openapi_data(**allof_model_args, **constant_args)
             else:
                 allof_instance = allof_class(**model_args, **constant_args)
             composed_instances.append(allof_instance)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Currently there is issue in dictionary conversion for the model, the generated dictionary has improper formatting for the keys(we can see some keys are in snake case, while others are in camel case) which is causing issue in few scripts built by using this SDK.

This can mainly observed in places the value is dictionary and property derives that value from allof, oneof or anyof schemas.

Expected Result :
```
{
   "id":4,
   "issues":{
      "issue":"Issue name",
      "priority":"P1"
   },
   "name":"child with int"
}
```

Actual Result:  In this result, issues key again dictionary inside which keys are in camel case, its also observed that id field which should be of type integer is in float
```
{
   "id":4.0,
   "issues":{
      "Issue":"Issue name",
      "Priority":"P1"
   },
   "name":"parent with int"
}
```




<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
