### PR TITLE
[Python] Update to check self to determine discarded attributes

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1670,6 +1670,11 @@ def get_discarded_args(self, composed_instances, model_args):
             except Exception:
                 # allOf integer schema will throw exception
                 pass
+    # Check if args exist in its attribute map of self and remove the key from discarded_args
+    keys = self.attribute_map.keys()
+    for key in keys:
+        if key in discarded_args:
+            discarded_args.remove(key)
     return discarded_args
 
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The previous fix for model to dictionary conversion issue had created new issue where attributes on self were not considered to determine discarded attributes. A fix is added to check if attributes on self is present in discarded arguments and remove them from discarded arguments
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
