### PR TITLE
[BUG][Python] Missing discriminator attributes on response object

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_from_openapi_data_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_from_openapi_data_composed.mustache
@@ -66,6 +66,9 @@
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         discarded_args = composed_info[3]
+        composed_keys = set()
+        for instance in self._composed_instances:
+            composed_keys.update(set(instance.attribute_map.values()))
 
         for var_name, var_value in kwargs.items():
             if var_name in discarded_args and \
@@ -73,6 +76,8 @@
                         self._configuration.discard_unknown_keys and \
                         self._additional_properties_model_instances:
                 # discard variable.
+                continue
+            if var_name in composed_keys:
                 continue
             setattr(self, var_name, var_value)
 

--- a/modules/openapi-generator/src/main/resources/python/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/methods_setattr_getattr_composed.mustache
@@ -34,12 +34,9 @@
                     [e for e in [self._path_to_item, name] if e]
                 )
         # attribute must be set on self and composed instances
-        model_instances = self._var_name_to_model_instances.get(name, self._additional_properties_model_instances)
-        for model_instance in model_instances:
-            if model_instance == self:
-                self.set_attribute(name, value)
-            else:
-                setattr(model_instance, name, value)
+        self.set_attribute(name, value)
+        for model_instance in self._composed_instances:
+            setattr(model_instance, name, value)
         if name not in self._var_name_to_model_instances:
             # we assigned an additional property
             self.__dict__['_var_name_to_model_instances'][name] = self._composed_instances + [self]

--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1371,9 +1371,10 @@ def model_to_dict(model_instance, serialize=True):
             item[1], serialize=serialize)) if hasattr(
         item[1], '_data_store') else item
 
-    model_instances = [model_instance]
+    model_instances = []
     if model_instance._composed_schemas:
         model_instances.extend(model_instance._composed_instances)
+    model_instances.append(model_instance)
     seen_json_attribute_names = set()
     used_fallback_python_attribute_names = set()
     py_to_json_map = {}
@@ -1490,14 +1491,10 @@ def get_allof_instances(self, model_args, constant_args):
     """
     composed_instances = []
     for allof_class in self._composed_schemas['allOf']:
-        allof_model_args = {}
-        var_names = set(allof_class.openapi_types.keys())
-        for var_name in var_names:
-            if var_name in model_args:
-                allof_model_args[var_name] = model_args[var_name]
         try:
             if constant_args.get('_spec_property_naming'):
-                allof_instance = allof_class._from_openapi_data(**allof_model_args, **constant_args)
+                model_data = dict(**model_args, **constant_args)
+                allof_instance = allof_class._new_from_openapi_data(**model_data)
             else:
                 allof_instance = allof_class(**model_args, **constant_args)
             composed_instances.append(allof_instance)
@@ -1670,11 +1667,6 @@ def get_discarded_args(self, composed_instances, model_args):
             except Exception:
                 # allOf integer schema will throw exception
                 pass
-    # Check if args exist in its attribute map of self and remove the key from discarded_args
-    keys = self.attribute_map.keys()
-    for key in keys:
-        if key in discarded_args:
-            discarded_args.remove(key)
     return discarded_args
 
 


### PR DESCRIPTION
In scenario where we have discriminator on class, attributes of discriminator were ignored as only attributes of base class were passed to initialize their values and attributes of discriminator class was ignored. The present fix changes the flow to determine the discriminator class and set attributes values on discriminator class as well while effectively avoiding data duplication across various composed classes.
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
