### PR TITLE
ISSDK-1279 : Backward compatibility

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_set_attribute.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_set_attribute.mustache
@@ -37,7 +37,10 @@
                 self._check_type, configuration=self._configuration)
                 
         # Check if validation should be skipped based on environment variable
-        skip_validation = os.environ.get("check_allowed_values", "True").lower() in ("false", "0")
+        # To disable allowed_values and validations checks, set environment variable:
+        # check_allowed_values=false
+        # Type validation will still be enforced regardless of this setting
+        skip_validation = os.environ.get("check_allowed_values", "True").lower() in ("false")
         if not skip_validation:
             if (name,) in self.allowed_values:
                 check_allowed_values(

--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_set_attribute.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_set_attribute.mustache
@@ -35,17 +35,21 @@
             value = validate_and_convert_types(
                 value, required_types_mixed, path_to_item, self._spec_property_naming,
                 self._check_type, configuration=self._configuration)
-        if (name,) in self.allowed_values:
-            check_allowed_values(
-                self.allowed_values,
-                (name,),
-                value
-            )
-        if (name,) in self.validations:
-            check_validations(
-                self.validations,
-                (name,),
-                value,
-                self._configuration
-            )
+                
+        # Check if validation should be skipped based on environment variable
+        skip_validation = os.environ.get("check_allowed_values", "True").lower() in ("false", "0")
+        if not skip_validation:
+            if (name,) in self.allowed_values:
+                check_allowed_values(
+                    self.allowed_values,
+                    (name,),
+                    value
+                )
+            if (name,) in self.validations:
+                check_validations(
+                    self.validations,
+                    (name,),
+                    value,
+                    self._configuration
+                )   
         self.__dict__['_data_store'][name] = value


### PR DESCRIPTION
This PR introduces a mechanism to maintain backward compatibility in the SDK when newer platform values are introduced.

- Added an environment variable check (check_allowed_values) to control validation behavior.
- If the environment variable is set to "false", validation is skipped.
- Otherwise, the existing validation logic runs

**Before Fix :** 
<img width="982" height="528" alt="e563ecdd-b490-4613-837c-41f1b35d598d" src="https://github.com/user-attachments/assets/e5459b13-3473-484f-9c44-9b3be5352d89" />

**After Fix :** 
<img width="988" height="245" alt="56546caf-b5b8-4631-b0f6-98b35ca5f1f3" src="https://github.com/user-attachments/assets/9fb6ec8d-513d-4a08-9b4c-13d029b29a1d" />