### PR TITLE
fix(csharp): numeric .NET version check to prevent double URL-encoding on .NET 9+ (CSCwu08056)

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
@@ -130,11 +130,17 @@ namespace {{packageName}}.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)


### PR DESCRIPTION
## Problem

`Get-IntersightIamAccount` returns `AuthenticationFailure / iam_api_key_is_invalid` on PowerShell 7.6 (ships .NET 10).

## Root Cause

In `HttpSigningConfiguration.cs`, HTTP signature auth builds a `(request-target)` by URL-encoding query parameter keys via `HttpUtility.UrlEncode()`. Starting with .NET 9, `HttpUtility.ParseQueryString()` already URL-encodes values internally. Calling `UrlEncode()` again causes double-encoding (e.g. `%24` → `%2524`). The signed `(request-target)` then differs from the actual wire URL → server rejects the signature.

The existing fix (from upstream PR #20651) used:
```csharp
framework.StartsWith(".NET 9")
```
This only matches .NET 9 literally. PowerShell 7.6 ships .NET 10, so the check fails and double-encoding resumes.

## Fix

Replace the `.NET 9`-only string check with a numeric major version comparison:
```csharp
bool skipUrlEncode = framework.StartsWith(".NET ") &&
    int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
```

This correctly covers .NET 9, 10, 11, and all future versions. The version check is also moved outside the `foreach` loop to avoid redundant parsing per parameter.

## File Changed

- `modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache`

Fixes: CSCwu08056