### PR TITLE
ISSDK-742: fix MoDisplayNames returns {Name} instead of actual values

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/AbstractOpenAPISchema.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/AbstractOpenAPISchema.mustache
@@ -1,8 +1,10 @@
 {{>partial_header}}
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using {{packageName}}.Client;
 
 namespace {{packageName}}.{{modelPackage}}
 {
@@ -19,13 +21,8 @@ namespace {{packageName}}.{{modelPackage}}
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -36,13 +33,8 @@ namespace {{packageName}}.{{modelPackage}}
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using System.Web;
 {{/net60OrLater}}
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -34,6 +35,108 @@ using {{packageName}}.{{modelPackage}};
 namespace {{packageName}}.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -43,13 +146,8 @@ namespace {{packageName}}.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -178,13 +276,8 @@ namespace {{packageName}}.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -35,6 +36,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -44,13 +147,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -178,13 +276,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -10,8 +10,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -28,13 +30,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -45,13 +42,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -35,6 +36,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -44,13 +147,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -178,13 +276,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -36,6 +37,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -45,13 +148,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -179,13 +277,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -36,6 +37,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -45,13 +148,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -179,13 +277,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -36,6 +37,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -45,13 +148,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -179,13 +277,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -35,6 +36,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -44,13 +147,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -178,13 +276,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/ParameterMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -34,6 +35,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -43,13 +146,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -177,13 +275,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/ParameterMappings/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/ParameterMappings/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -35,6 +36,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -44,13 +147,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -178,13 +276,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -34,6 +35,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -43,13 +146,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -177,13 +275,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -35,6 +36,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -44,13 +147,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -178,13 +276,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -36,6 +37,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -45,13 +148,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -179,13 +277,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers;
@@ -36,6 +37,108 @@ using Org.OpenAPITools.Model;
 namespace Org.OpenAPITools.Client
 {
     /// <summary>
+    /// Custom contract resolver that allows deserialization of properties with private setters.
+    /// This is needed because the OpenAPI generator marks read-only properties with private setters,
+    /// but Newtonsoft.Json's DefaultContractResolver does not populate them by default.
+    /// </summary>
+    internal class NonPublicSetterContractResolver : DefaultContractResolver
+    {
+        public NonPublicSetterContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy
+            {
+                OverrideSpecifiedNames = false
+            };
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var prop = base.CreateProperty(member, memberSerialization);
+
+            if (!prop.Writable)
+            {
+                var property = member as System.Reflection.PropertyInfo;
+                if (property != null)
+                {
+                    prop.Writable = property.GetSetMethod(true) != null;
+                }
+            }
+
+            return prop;
+        }
+    }
+
+    /// <summary>
+    /// Converts Object-typed properties from JObject/JArray to native .NET Dictionary/List
+    /// so that PowerShell and other consumers can access nested values directly.
+    /// </summary>
+    internal class ObjectToNativeDictionaryConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(object);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObj = JObject.Load(reader);
+                return ConvertJToken(jObj);
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArr = JArray.Load(reader);
+                return ConvertJToken(jArr);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                // Primitive value
+                return serializer.Deserialize(reader);
+            }
+        }
+
+        private object ConvertJToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (var prop in ((JObject)token).Properties())
+                    {
+                        dict[prop.Name] = ConvertJToken(prop.Value);
+                    }
+                    return dict;
+                case JTokenType.Array:
+                    var list = new List<object>();
+                    foreach (var item in (JArray)token)
+                    {
+                        list.Add(ConvertJToken(item));
+                    }
+                    // Flatten single-element arrays to scalar for cleaner display
+                    if (list.Count == 1)
+                    {
+                        return list[0];
+                    }
+                    return list;
+                default:
+                    return ((JValue)token).Value;
+            }
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("ObjectToNativeDictionaryConverter is read-only.");
+        }
+    }
+
+    /// <summary>
     /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
     /// </summary>
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
@@ -45,13 +148,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         public CustomJsonCodec(IReadableConfiguration configuration)
@@ -179,13 +277,8 @@ namespace Org.OpenAPITools.Client
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -138,11 +138,17 @@ namespace Org.OpenAPITools.Client
             }
 
             var httpValues = HttpUtility.ParseQueryString(string.Empty);
+#if (NETCOREAPP)
+            // On .NET 9+, ParseQueryString already URL-encodes values.
+            // Skip UrlEncode to prevent double-encoding that causes signature mismatches.
+            string framework = RuntimeInformation.FrameworkDescription;
+            bool skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int major) && major >= 9;
+#endif
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
+                string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -9,8 +9,10 @@
 
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Org.OpenAPITools.Client;
 
 namespace Org.OpenAPITools.Model
 {
@@ -27,13 +29,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>
@@ -44,13 +41,8 @@ namespace Org.OpenAPITools.Model
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
             MissingMemberHandling = MissingMemberHandling.Ignore,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
+            ContractResolver = new NonPublicSetterContractResolver(),
+            Converters = new List<JsonConverter> { new ObjectToNativeDictionaryConverter() }
         };
 
         /// <summary>


### PR DESCRIPTION
## Problem
`Get-IntersightAaaAuditRecord | select ObjectMoid,MoDisplayNames` displays `{Name}` (JObject key) instead of actual values like `BT-ntp-policy`.

## Root Cause
For response types extending `AbstractOpenAPISchema` (oneOf/anyOf wrappers like `AaaAuditRecordResponse`), `ApiClient.ExecClientAsync` calls `FromJson()` which re-deserializes using `AbstractOpenAPISchema.SerializerSettings`. These settings lacked the custom converter, so `System.Object`-typed properties (like `MoDisplayNames`) were left as raw `JObject`/`JArray` instead of being converted to native .NET types.

## Fix
- **`ApiClient.mustache`**: Added `NonPublicSetterContractResolver` (enables private-setter deserialization with camelCase mapping) and `ObjectToNativeDictionaryConverter` (converts JObject to Dictionary, JArray to List, flattens single-element arrays to scalar for cleaner display).
- **`AbstractOpenAPISchema.mustache`**: Updated both `SerializerSettings` and `AdditionalPropertiesSerializerSettings` to use the same resolver and converter, ensuring the `FromJson` deserialization path produces native .NET types.

## Result
Before: `MoDisplayNames : {Name}`
After: `MoDisplayNames : {[Name, BT-ntp-policy]}`
