### PR TITLE
 ISSDK-512: Skip pattern validation for read-only properties in Python SDK

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_set_attribute.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_set_attribute.mustache
@@ -41,6 +41,13 @@
         # check_allowed_values=false
         # Type validation will still be enforced regardless of this setting
         skip_validation = os.environ.get("check_allowed_values", "True").lower() in ("false")
+        
+        # Skip pattern/regex validation for read-only properties since they are
+        # server-provided values and should not be validated client-side.
+        # This fixes issues where server returns data that doesn't match restrictive
+        # patterns defined in the OpenAPI spec (e.g., cluster names with dots).
+        is_read_only = hasattr(self, 'read_only_vars') and name in self.read_only_vars
+        
         if not skip_validation:
             if (name,) in self.allowed_values:
                 check_allowed_values(
@@ -48,7 +55,8 @@
                     (name,),
                     value
                 )
-            if (name,) in self.validations:
+            # Skip regex/pattern validation for read-only properties
+            if (name,) in self.validations and not is_read_only:
                 check_validations(
                     self.validations,
                     (name,),


### PR DESCRIPTION
## Problem
TamApi.get_tam_advisory_instance_list with expand option on AffectedObject fails with:
`Invalid value for 'name', must match regular expression '^[a-zA-Z0-9]+[\sa-zA-Z0-9_-]{1,32}$'`

Read-only properties like `infra.BaseCluster.Name` have restrictive regex patterns that reject valid server-provided data (e.g., cluster names with dots like `HX-Cluster.Domain.Local`).

## Solution
Skip regex/pattern validation for read-only properties during deserialization since they are server-provided values.

## Testing
- Jenkins Job: http://sam-tools01:8080/view/Fix-Jobs/job/Fix-Akhil/863
- Verified locally: Names with dots, @, special chars now deserialize successfully