### PR TITLE
ISSDK-1876: Skip x-createOnly defaults in Go NewXxx/NewXxxWithDefaults constructors

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -51,6 +51,7 @@ func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}
 {{#defaultValue}}
 {{^vendorExtensions.x-golang-is-container}}
 {{^isReadOnly}}
+{{^vendorExtensions.x-createOnly}}
 {{#isNullable}}
 	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
 	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
@@ -59,6 +60,7 @@ func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}
 	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
 	this.{{name}} = &{{nameInCamelCase}}
 {{/isNullable}}
+{{/vendorExtensions.x-createOnly}}
 {{/isReadOnly}}
 {{/vendorExtensions.x-golang-is-container}}
 {{/defaultValue}}
@@ -76,6 +78,7 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{#defaultValue}}
 {{^vendorExtensions.x-golang-is-container}}
 {{^isReadOnly}}
+{{^vendorExtensions.x-createOnly}}
 {{#isNullable}}
 {{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
 	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
@@ -85,6 +88,7 @@ func New{{classname}}WithDefaults() *{{classname}} {
 	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
 	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
 {{/isNullable}}
+{{/vendorExtensions.x-createOnly}}
 {{/isReadOnly}}
 {{/vendorExtensions.x-golang-is-container}}
 {{/defaultValue}}


### PR DESCRIPTION
## Summary

Fixes the Go SDK sending `x-createOnly` property defaults on resource creation, which the Intersight API rejects (e.g. `server_family`).

## Change

`go/model_simple.mustache` (+4): the generated `NewXxx()` / `NewXxxWithDefaults()` constructors no longer assign default values for properties marked `x-createOnly`. Previously a `x-createOnly` property with a default (e.g. `ServerFamily = "Unspecified"`) was initialised in the constructor and then sent in the POST body, causing `400 "Cannot modify the read-only property ..."`.

This is the Go-SDK analog of the Terraform `createOnly -> Computed` fix.

## Scope

- Affects the **Go** generator only.
- Cisco-specific (`x-createOnly` is an Intersight extension) — not an upstream candidate.

Ticket: ISSDK-1876
