### PR TITLE
ISSDK-1893: CI: Fix Gradle setup on Linux/Windows and update GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: gradle
 
       - uses: actions/cache@v5
         with:
@@ -50,6 +51,12 @@ jobs:
           java-version: ${{ matrix.java }}
           maven-version: 3.8.8
 
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-disabled: true
+          gradle-version: '8.14.3'
+          validate-wrappers: false
+
       - name: Build with Maven
         shell: bash
         run: ./mvnw clean -nsu -B --quiet -Dorg.slf4j.simpleLogger.defaultLogLevel=error --no-transfer-progress install --file pom.xml
@@ -57,7 +64,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       - name: Upload Maven build artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: matrix.java == '11' && matrix.os == 'ubuntu-latest'
         with:
           name: artifact
@@ -65,7 +72,7 @@ jobs:
 
       - name: Test Gradle plugin usage
         shell: bash
-        run: gradle -b modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle buildGoSdk --stacktrace
+        run: gradle --project-dir modules/openapi-generator-gradle-plugin/samples/local-spec buildGoSdk --stacktrace
 
       - name: Test Maven plugin integration
         if: matrix.java == '11'
@@ -91,6 +98,7 @@ jobs:
         with:
           java-version: 11
           maven-version: 3.8.8
+          cache: gradle
       - name: Download build artifact
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,22 +20,22 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml', 'modules/**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Setup Maven
-        uses: s4u/setup-maven-action@v1.18.0
+        uses: s4u/setup-maven-action@v1.20.0
         with:
           java-version: ${{ matrix.java }}
           maven-version: 3.8.8
@@ -57,7 +57,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       - name: Upload Maven build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: matrix.java == '11' && matrix.os == 'ubuntu-latest'
         with:
           name: artifact
@@ -85,14 +85,14 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Maven
-        uses: s4u/setup-maven-action@v1.18.0
+        uses: s4u/setup-maven-action@v1.20.0
         with:
           java-version: 11
           maven-version: 3.8.8
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifact
       - name: Run Ensures Script

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: gradle
       - name: Cache maven dependencies
         uses: actions/cache@v5
         env:
@@ -54,6 +55,8 @@ jobs:
           java -jar ./openapi-generator-cli.jar author template --verbose  -g jaxrs-spec --library quarkus
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: '8.14.3'
       - name: Gradle tests
         run: |
-          gradle -b modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle buildGoSdk --stacktrace
+          gradle --project-dir modules/openapi-generator-gradle-plugin/samples/local-spec buildGoSdk --stacktrace

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,14 +18,14 @@ jobs:
       matrix:
         java: [11, 17]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Cache maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-maven-repository
         with:
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
       - name: Setup Maven
-        uses: s4u/setup-maven-action@v1.18.0
+        uses: s4u/setup-maven-action@v1.20.0
         with:
           java-version: ${{ matrix.java }}
           maven-version: 3.8.8


### PR DESCRIPTION
## Summary

Fixes CI infrastructure issues in the GitHub Actions workflows for `CiscoM31/openapi-generator`. These changes were previously bundled in PR #176 (ISSDK-692) and have been split out into their own PR under **ISSDK-1893**.

## Changes

### `.github/workflows/linux.yaml`
- Add `gradle/actions/setup-gradle@v6` with pinned `gradle-version: 8.14.3`
- Add `cache: gradle` to `setup-java` steps
- Update Gradle command syntax from `gradle -b <build.gradle>` to `gradle --project-dir <dir>`
- Update `upload-artifact` to v7

### `.github/workflows/windows.yaml`
- Add `gradle-version` parameter to the Windows Gradle setup
- Add `cache: gradle` to `setup-java` steps

### GitHub Actions Node.js 20 deprecation
- Update actions to v5 (`checkout@v5`, `setup-java@v5`, `cache@v5`, `download-artifact@v5`), `upload-artifact@v7`, and `s4u/setup-maven-action@v1.20.0` to move off the deprecated Node.js 20 runner.

## Why

- The Linux/Windows Gradle jobs were failing due to an unmanaged/incompatible Gradle version. Pinning Gradle 8.14.3 via `gradle/actions/setup-gradle@v6` and using `--project-dir` makes the builds reproducible.
- GitHub deprecated the Node.js 20 action runtime; older action versions emit deprecation warnings and will eventually fail. Bumping to v5/v7 actions resolves this.

## Related
- Split out from PR #176 (ISSDK-692: text/plain JSON responses in Go SDK decode()), which now contains only the Go SDK fix.
- JIRA: ISSDK-1893